### PR TITLE
Feature/request params

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ Or
       institution!("INSTITUTION").title_begins_with("Travels").
         creator_contains("Greene").genre_is("Book")
 
+Search can be expanded when using Ex Libris Primo Central by adding a request parametertrue
+
+     search = Exlibris::Primo::Search.new(:base_url => "http://primo.institution.edu",
+       :institution => "INSTITUTION", :page_size => "20")
+     search.add_query_term "0143039008", "isbn", "exact"
+     search.add_request_param('pc_availability_ind','true') # adding this line will expand the results
+     count = search.size #=> 20+ (assuming there are 20+ records with this isbn)
+     facets = search.facets #=> Array of Primo facets
+     records = search.records #=> Array of Primo records
+     records.size #=> 20 (assuming there are 20+ records with this isbn)
+     records.each do |record_id, record|
+       holdings = record.holdings #=> Array of Primo holdings
+       fulltexts = record.fulltexts #=> Array of Primo full texts
+       table_of_contents = record.table_of_contents #=> Array of Primo tables of contents
+       related_links = record.related_links #=> Array of Primo related links
+     end
+
+
+
 ## Exlibris::Primo::Config
 Exlibris::Primo::Config allows you to specify global configuration parameter for Exlibris::Primo
 

--- a/lib/exlibris/primo/chain_gang/search.rb
+++ b/lib/exlibris/primo/chain_gang/search.rb
@@ -73,14 +73,28 @@ module Exlibris
           self
         end
 
-        # 
-        # Dynamically sets chainable accessor for indexes and 
+        #
+        # Adds a request param to the search.
+        # Suitable for chaining, e.g.
+        #
+        #     Search.new
+        #       .add_request_param("pc_availability_ind", "true")
+        #       .add_request_param("pyrCategories", "medicine;business")
+        #       .search
+        #
+        def add_request_param(*args)
+          search_request.add_request_param(*args)
+          self
+        end
+
+        #
+        # Dynamically sets chainable accessor for indexes and
         # precisions
         # Suitable for chaining, e.g.
         #
         #     Search.new.title_begins_with("Travels").
         #       creator_contains("Greene").search
-        # 
+        #
         def method_missing(method, *args, &block)
           if matches? method
             self.class.send(:define_method, method) { |value|

--- a/lib/exlibris/primo/web_service/request/search.rb
+++ b/lib/exlibris/primo/web_service/request/search.rb
@@ -2,9 +2,9 @@ module Exlibris
   module Primo
     module WebService
       module Request
-        # 
+        #
         # Search Primo
-        # 
+        #
         class Search < Base
           self.has_client
           self.soap_action = :search_brief
@@ -15,7 +15,7 @@ module Exlibris
           include SearchElements
           include SortBys
 
-          add_default_search_elements :start_index => "1", 
+          add_default_search_elements :start_index => "1",
             :bulk_size => "5", :did_u_mean_enabled => "false"
 
           add_search_elements :start_index, :bulk_size, :did_u_mean_enabled,
@@ -24,6 +24,7 @@ module Exlibris
           def to_xml
             super { |xml|
               xml.PrimoSearchRequest("xmlns" => "http://www.exlibris.com/primo/xsd/search/request") {
+                request_params_xml.call xml
                 query_terms_xml.call xml
                 search_elements_xml.call xml
                 languages_xml.call xml
@@ -35,9 +36,9 @@ module Exlibris
           end
         end
 
-        # 
+        #
         # Get a specific record from Primo.
-        # 
+        #
         class FullView < Search
           # Add doc_id to the base elements
           self.add_base_elements :doc_id

--- a/lib/exlibris/primo/web_service/request/search.rb
+++ b/lib/exlibris/primo/web_service/request/search.rb
@@ -12,6 +12,7 @@ module Exlibris
           include Languages
           include Locations
           include QueryTerms
+          include RequestParams
           include SearchElements
           include SortBys
 

--- a/lib/exlibris/primo/web_service/request/search/request_param.rb
+++ b/lib/exlibris/primo/web_service/request/search/request_param.rb
@@ -1,0 +1,24 @@
+module Exlibris
+  module Primo
+    module WebService
+      module Request
+        #
+        #
+        #
+        class RequestParam
+          include WriteAttributes
+          include XmlUtil
+          attr_accessor :key, :value
+
+          def to_xml
+            build_xml do |xml|
+              xml.RequestParam(:key => key) {
+                xml << value
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/exlibris/primo/web_service/request/search/request_params.rb
+++ b/lib/exlibris/primo/web_service/request/search/request_params.rb
@@ -1,0 +1,32 @@
+module Exlibris
+  module Primo
+    module WebService
+      module Request
+        module RequestParams
+          #
+          # Returns a lambda that takes a Nokogiri::XML::Builder as an argument
+          # and appends query terms XML to it.
+          #
+          def request_params_xml
+            lambda do |xml|
+              xml.RequestParams {
+                request_params.each do |request_param|
+                  xml << request_param.to_xml
+                end
+              }
+            end
+          end
+          protected :request_params_xml
+
+          def request_params
+            @request_params ||= []
+          end
+
+          def add_request_param(value, key)
+            request_params << RequestParam.new(:value => value, :key => key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/exlibris/primo/web_service/request/search/request_params.rb
+++ b/lib/exlibris/primo/web_service/request/search/request_params.rb
@@ -22,8 +22,8 @@ module Exlibris
             @request_params ||= []
           end
 
-          def add_request_param(value, key)
-            request_params << RequestParam.new(:value => value, :key => key)
+          def add_request_param(key, value)
+            request_params << RequestParam.new(:key => key, :value => value)
           end
         end
       end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -130,7 +130,7 @@ class SearchTest < Test::Unit::TestCase
     VCR.use_cassette('search sort by locations') do
       search = Exlibris::Primo::Search.new.base_url!(@base_url).
         institution!(@institution).any_contains("digital divide").
-          add_sort_by("stitle").add_local_location("scope:(NYU)")
+        add_sort_by("stitle").add_local_location("scope:(NYU)")
       assert_not_nil search.size
       assert_not_nil search.facets
       assert((not search.facets.empty?))
@@ -202,7 +202,7 @@ class SearchTest < Test::Unit::TestCase
     VCR.use_cassette('search enable highlighting') do
       search = Exlibris::Primo::Search.new.base_url!(@base_url).
         institution!(@institution).title_contains("digital divide").
-          enable_highlighting.add_display_field("title")
+        enable_highlighting.add_display_field("title")
       assert_not_nil search.size
       assert_not_nil search.facets
       assert((not search.facets.empty?))
@@ -218,7 +218,7 @@ class SearchTest < Test::Unit::TestCase
     VCR.use_cassette('search sort by') do
       search = Exlibris::Primo::Search.new.base_url!(@base_url).
         institution!(@institution).title_contains("digital divide").
-          add_sort_by("stitle")
+        add_sort_by("stitle")
       assert_not_nil search.size
       assert_not_nil search.facets
       assert((not search.facets.empty?))
@@ -226,10 +226,10 @@ class SearchTest < Test::Unit::TestCase
       assert((not search.records.empty?))
       sorted_titles = []
       search.records.each do |record|
-        sorted_titles<< record.display_title
+        sorted_titles << record.display_title
       end
-      sorted_titles.sort.each_index {|index|
-        assert(sorted_titles[index].eql?(sorted_titles.sort[index]), "Sort failed.")}
+      sorted_titles.sort.each_index { |index|
+        assert(sorted_titles[index].eql?(sorted_titles.sort[index]), "Sort failed.") }
     end
   end
 
@@ -237,7 +237,7 @@ class SearchTest < Test::Unit::TestCase
     VCR.use_cassette('search languages') do
       search = Exlibris::Primo::Search.new.base_url!(@base_url).
         institution!(@institution).title_contains("digital divide").
-          add_language("en")
+        add_language("en")
       assert_not_nil search.size
       assert_not_nil search.facets
       assert((not search.facets.empty?))
@@ -326,8 +326,8 @@ class SearchTest < Test::Unit::TestCase
   def test_and_or_methods
     assert_nothing_raised {
       search = Exlibris::Primo::Search.new
-      assert search.class.public_instance_methods.collect{|m|m.to_sym}.include? :and
-      assert search.class.public_instance_methods.collect{|m|m.to_sym}.include? :or
+      assert search.class.public_instance_methods.collect { |m| m.to_sym }.include? :and
+      assert search.class.public_instance_methods.collect { |m| m.to_sym }.include? :or
       assert_equal "AND", search.send(:search_request).boolean_operator
       assert_equal "OR", search.or.send(:search_request).boolean_operator
       assert_equal "AND", search.and.send(:search_request).boolean_operator
@@ -343,5 +343,15 @@ class SearchTest < Test::Unit::TestCase
       assert_not_nil search.did_u_mean
       assert_equal "digital video", search.did_u_mean
     end
+  end
+
+  def test_add_request_param
+    key = 'pc_availability_ind'
+    value = 'true'
+    search = Exlibris::Primo::Search.new
+    assert_equal search.add_request_param(key, value), search
+
+    search_request = search.send(:search_request)
+    assert_equal search_request.request_params.count, 1
   end
 end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -353,5 +353,7 @@ class SearchTest < Test::Unit::TestCase
 
     search_request = search.send(:search_request)
     assert_equal search_request.request_params.count, 1
+    assert_equal search_request.request_params.first.key, key
+    assert_equal search_request.request_params.first.value, value
   end
 end

--- a/test/web_service/request/request_param_test.rb
+++ b/test/web_service/request/request_param_test.rb
@@ -1,0 +1,27 @@
+module WebService
+  module Request
+    require 'test_helper'
+    class RequestParamTest < Test::Unit::TestCase
+      def setup
+        @key = 'pc_availability_ind'
+        @value = 'true'
+      end
+
+      def test_set_attributes
+        param = Exlibris::Primo::WebService::Request::RequestParam.new()
+        param.key = @key
+        param.value = @value
+        assert_equal "<RequestParam key=\"pc_availability_ind\">" \
+                     "true" \
+                     "</RequestParam>", param.to_xml
+      end
+
+      def test_write_attributes
+        param = Exlibris::Primo::WebService::Request::RequestParam.new(:key => 'pc_availability_ind', :value => 'true')
+        assert_equal "<RequestParam key=\"pc_availability_ind\">" \
+                     "true" \
+                     "</RequestParam>", param.to_xml
+      end
+    end
+  end
+end

--- a/test/web_service/request/request_param_test.rb
+++ b/test/web_service/request/request_param_test.rb
@@ -11,15 +11,15 @@ module WebService
         param = Exlibris::Primo::WebService::Request::RequestParam.new()
         param.key = @key
         param.value = @value
-        assert_equal "<RequestParam key=\"pc_availability_ind\">" \
-                     "true" \
+        assert_equal "<RequestParam key=\"#{@key}\">" \
+                     "#{@value}" \
                      "</RequestParam>", param.to_xml
       end
 
       def test_write_attributes
         param = Exlibris::Primo::WebService::Request::RequestParam.new(:key => 'pc_availability_ind', :value => 'true')
-        assert_equal "<RequestParam key=\"pc_availability_ind\">" \
-                     "true" \
+        assert_equal "<RequestParam key=\"#{@key}\">" \
+                     "#{@value}" \
                      "</RequestParam>", param.to_xml
       end
     end

--- a/test/web_service/request/request_params_test.rb
+++ b/test/web_service/request/request_params_test.rb
@@ -1,0 +1,59 @@
+module WebService
+  module Request
+    require 'test_helper'
+    class RequestParamTest < Test::Unit::TestCase
+      class SearchDummy
+        include Exlibris::Primo::WebService::Request::RequestParams
+        include Exlibris::Primo::XmlUtil
+        def to_xml
+          build_xml { |xml|
+            request_params_xml.call xml
+          }
+        end
+      end
+
+      def setup
+        @key_1 = 'pc_availability_ind'
+        @value_1 = 'true'
+        @key_2 = 'pyrCategories'
+        @value_2 = 'medicine;business'
+      end
+
+      def test_add_request_param
+        search = SearchDummy.new
+        search.add_request_param(@key_1, @value_1)
+        search.add_request_param(@key_2, @value_2)
+        assert_equal @key_1, search.request_params[0].key
+        assert_equal @value_1, search.request_params[0].value
+        assert_equal @key_2, search.request_params[1].key
+        assert_equal @value_2, search.request_params[1].value
+      end
+
+
+      def test_request_params
+        search = SearchDummy.new
+        assert_equal [], search.request_params
+      end
+
+      def test_request_params_xml_with_no_params
+        search = SearchDummy.new
+        assert_equal '', search.to_xml
+      end
+
+      def test_request_params_xml_with_params
+        search = SearchDummy.new
+        search.add_request_param(@key_1, @value_1)
+        search.add_request_param(@key_2, @value_2)
+        assert_equal "<RequestParams>" \
+                     "<RequestParam key=\"#{@key_1}\">" \
+                     "#{@value_1}" \
+                     "</RequestParam>" \
+                     "<RequestParam key=\"#{@key_2}\">" \
+                     "#{@value_2}" \
+                     "</RequestParam>" \
+                     "</RequestParams>", search.to_xml
+
+      end
+    end
+  end
+end

--- a/test/web_service/request/request_params_test.rb
+++ b/test/web_service/request/request_params_test.rb
@@ -1,10 +1,11 @@
 module WebService
   module Request
     require 'test_helper'
-    class RequestParamTest < Test::Unit::TestCase
+    class RequestParamsTest < Test::Unit::TestCase
       class SearchDummy
         include Exlibris::Primo::WebService::Request::RequestParams
         include Exlibris::Primo::XmlUtil
+
         def to_xml
           build_xml { |xml|
             request_params_xml.call xml
@@ -37,7 +38,7 @@ module WebService
 
       def test_request_params_xml_with_no_params
         search = SearchDummy.new
-        assert_equal '', search.to_xml
+        assert_equal "<RequestParams/>", search.to_xml
       end
 
       def test_request_params_xml_with_params

--- a/test/web_service/request/search_test.rb
+++ b/test/web_service/request/search_test.rb
@@ -18,6 +18,7 @@ module WebService
           :institution => @institution, :doc_id => @doc_id
         assert_request request, "fullViewRequest",
           "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+          "<RequestParams/>"+
           "<QueryTerms><BoolOpeator>AND</BoolOpeator></QueryTerms>"+
           "<StartIndex>1</StartIndex>"+
           "<BulkSize>5</BulkSize>"+
@@ -37,6 +38,7 @@ module WebService
           request.add_query_term @issn, "isbn", "exact"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>isbn</IndexField>"+
             "<PrecisionOperator>exact</PrecisionOperator>"+
@@ -59,6 +61,7 @@ module WebService
           request.add_query_term @isbn, "isbn", "exact"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>isbn</IndexField>"+
             "<PrecisionOperator>exact</PrecisionOperator>"+
@@ -81,6 +84,7 @@ module WebService
           request.add_query_term @title, "title"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>title</IndexField>"+
             "<PrecisionOperator>contains</PrecisionOperator>"+
@@ -104,6 +108,7 @@ module WebService
           request.add_query_term "Digital dvide", "title"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>title</IndexField>"+
             "<PrecisionOperator>contains</PrecisionOperator>"+
@@ -126,6 +131,7 @@ module WebService
           request.add_query_term @author, "creator"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>creator</IndexField>"+
             "<PrecisionOperator>contains</PrecisionOperator>"+
@@ -148,6 +154,7 @@ module WebService
           request.add_query_term @genre, "any", "exact"
           assert_request request, "searchRequest",
             "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+            "<RequestParams/>"+
             "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
             "<IndexField>any</IndexField>"+
             "<PrecisionOperator>exact</PrecisionOperator>"+
@@ -163,7 +170,7 @@ module WebService
             }
           end
       end
-      
+
       def test_search_locations
         request = Exlibris::Primo::WebService::Request::Search.new :base_url => @base_url
         request.institution = @institution
@@ -171,6 +178,7 @@ module WebService
         request.add_location "local", "scope:(NYU)"
         assert_request request, "searchRequest",
           "<PrimoSearchRequest xmlns=\"http://www.exlibris.com/primo/xsd/search/request\">"+
+          "<RequestParams/>"+
           "<QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm>"+
           "<IndexField>isbn</IndexField>"+
           "<PrecisionOperator>exact</PrecisionOperator>"+
@@ -215,8 +223,8 @@ module WebService
                     "<Value>Book</Value></QueryTerm>"].include? xmlize(great_grand_child)
                 end
               else
-                assert ["<StartIndex>1</StartIndex>", "<BulkSize>5</BulkSize>", 
-                  "<DidUMeanEnabled>false</DidUMeanEnabled>"].include? xmlize(grand_child)
+                assert ["<StartIndex>1</StartIndex>", "<BulkSize>5</BulkSize>",
+                  "<DidUMeanEnabled>false</DidUMeanEnabled>", "<RequestParams/>"].include? xmlize(grand_child)
               end
             end
           else


### PR DESCRIPTION
Adding support for RequestParams.  For specific details see the [Ex Libris Brief Search](https://developers.exlibrisgroup.com/primo/apis/webservices/soap/search/briefsearch_soap) documentation.

The main driver for my projects was perform a search against the Primo API that would simulate a user doing a search with the the "Expand My Results" checked in the Primo Web UI.  This can be achieved by adding the following XML to a search request:

```xml
<RequestParams>
  <RequestParam key="pc_availability_ind">
     true
  </RequestParam>
</RequestParams>
```
